### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/eventbuslib/src/main/java/de/greenrobot/event/EventBus.java
+++ b/eventbuslib/src/main/java/de/greenrobot/event/EventBus.java
@@ -42,7 +42,7 @@ public class EventBus {
     /** Log tag, apps may override it. */
     public static String TAG = "Event";
 
-    static volatile EventBus defaultInstance;
+    protected static volatile EventBus defaultInstance;
 
     private static final EventBusBuilder DEFAULT_BUILDER = new EventBusBuilder();
     private static final Map<Class<?>, List<Class<?>>> eventTypesCache = new HashMap<>();
@@ -547,12 +547,12 @@ public class EventBus {
 
     /** For ThreadLocal, much faster to set (and get multiple values). */
     final static class PostingThreadState {
-        final List<Object> eventQueue = new ArrayList<>();
-        boolean isPosting;
-        boolean isMainThread;
-        Subscription subscription;
-        Object event;
-        boolean canceled;
+        private final List<Object> eventQueue = new ArrayList<>();
+        private boolean isPosting;
+        private boolean isMainThread;
+        private Subscription subscription;
+        private Object event;
+        private boolean canceled;
     }
 
     ExecutorService getExecutorService() {

--- a/eventbuslib/src/main/java/de/greenrobot/event/EventBusBuilder.java
+++ b/eventbuslib/src/main/java/de/greenrobot/event/EventBusBuilder.java
@@ -27,14 +27,14 @@ import java.util.concurrent.Executors;
 public class EventBusBuilder {
     private final static ExecutorService DEFAULT_EXECUTOR_SERVICE = Executors.newCachedThreadPool();
 
-    boolean logSubscriberExceptions = true;
-    boolean logNoSubscriberMessages = true;
-    boolean sendSubscriberExceptionEvent = true;
-    boolean sendNoSubscriberEvent = true;
-    boolean throwSubscriberException;
-    boolean eventInheritance = true;
-    ExecutorService executorService = DEFAULT_EXECUTOR_SERVICE;
-    List<Class<?>> skipMethodVerificationForClasses;
+    protected boolean logSubscriberExceptions = true;
+    protected boolean logNoSubscriberMessages = true;
+    protected boolean sendSubscriberExceptionEvent = true;
+    protected boolean sendNoSubscriberEvent = true;
+    protected boolean throwSubscriberException;
+    protected boolean eventInheritance = true;
+    protected ExecutorService executorService = DEFAULT_EXECUTOR_SERVICE;
+    protected List<Class<?>> skipMethodVerificationForClasses;
 
     EventBusBuilder() {
     }

--- a/eventbuslib/src/main/java/de/greenrobot/event/PendingPost.java
+++ b/eventbuslib/src/main/java/de/greenrobot/event/PendingPost.java
@@ -21,9 +21,9 @@ import java.util.List;
 final class PendingPost {
     private final static List<PendingPost> pendingPostPool = new ArrayList<>();
 
-    Object event;
-    Subscription subscription;
-    PendingPost next;
+    protected Object event;
+    protected Subscription subscription;
+    protected PendingPost next;
 
     private PendingPost(Object event, Subscription subscription) {
         this.event = event;

--- a/eventbuslib/src/main/java/de/greenrobot/event/SubscriberMethod.java
+++ b/eventbuslib/src/main/java/de/greenrobot/event/SubscriberMethod.java
@@ -18,11 +18,11 @@ package de.greenrobot.event;
 import java.lang.reflect.Method;
 
 final class SubscriberMethod {
-    final Method method;
-    final ThreadMode threadMode;
-    final Class<?> eventType;
+    protected final Method method;
+    protected final ThreadMode threadMode;
+    protected final Class<?> eventType;
     /** Used for efficient comparison */
-    String methodString;
+    protected String methodString;
 
     SubscriberMethod(Method method, ThreadMode threadMode, Class<?> eventType) {
         this.method = method;

--- a/eventbuslib/src/main/java/de/greenrobot/event/Subscription.java
+++ b/eventbuslib/src/main/java/de/greenrobot/event/Subscription.java
@@ -16,9 +16,9 @@
 package de.greenrobot.event;
 
 final class Subscription {
-    final Object subscriber;
-    final SubscriberMethod subscriberMethod;
-    final int priority;
+    protected final Object subscriber;
+    protected final SubscriberMethod subscriberMethod;
+    protected final int priority;
     /**
      * Becomes false as soon as {@link de.greenrobot.event.EventBus#unregister(Object)} is called, which is checked by queued event delivery
      * {@link de.greenrobot.event.EventBus#invokeSubscriber(de.greenrobot.event.PendingPost)} to prevent race conditions.

--- a/eventbuslib/src/main/java/de/greenrobot/event/util/ErrorDialogConfig.java
+++ b/eventbuslib/src/main/java/de/greenrobot/event/util/ErrorDialogConfig.java
@@ -5,16 +5,16 @@ import android.util.Log;
 import de.greenrobot.event.EventBus;
 
 public class ErrorDialogConfig {
-    final Resources resources;
-    final int defaultTitleId;
-    final int defaultErrorMsgId;
-    final ExceptionToResourceMapping mapping;
+    protected final Resources resources;
+    protected final int defaultTitleId;
+    private final int defaultErrorMsgId;
+    protected final ExceptionToResourceMapping mapping;
 
-    EventBus eventBus;
-    boolean logExceptions = true;
-    String tagForLoggingExceptions;
-    int defaultDialogIconId;
-    Class<?> defaultEventTypeOnDialogClosed;
+    protected EventBus eventBus;
+    protected boolean logExceptions = true;
+    protected String tagForLoggingExceptions;
+    protected int defaultDialogIconId;
+    protected Class<?> defaultEventTypeOnDialogClosed;
 
     public ErrorDialogConfig(Resources resources, int defaultTitleId, int defaultMsgId) {
         this.resources = resources;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat
