### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/eventbuslib/src/main/java/de/greenrobot/event/util/ErrorDialogFragments.java
+++ b/eventbuslib/src/main/java/de/greenrobot/event/util/ErrorDialogFragments.java
@@ -12,12 +12,14 @@ import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import de.greenrobot.event.EventBus;
 
-public class ErrorDialogFragments {
+public final class ErrorDialogFragments {
     /** TODO Use config:  Icon res ID to use for all error dialogs. May be configured by each app (optional). */
     public static int ERROR_DIALOG_ICON = 0;
 
     /** TODO Use config:  Event class to be fired on dismissing the dialog by the user. May be configured by each app. */
     public static Class<?> EVENT_TYPE_ON_CLICK;
+
+    private ErrorDialogFragments () {}
 
     public static Dialog createDialog(Context context, Bundle arguments, OnClickListener onClickListener) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);

--- a/eventbuslib/src/main/java/de/greenrobot/event/util/ErrorDialogManager.java
+++ b/eventbuslib/src/main/java/de/greenrobot/event/util/ErrorDialogManager.java
@@ -26,7 +26,9 @@ import de.greenrobot.event.EventBus;
  * 
  * @author Markus
  */
-public class ErrorDialogManager {
+public final class ErrorDialogManager {
+
+    private ErrorDialogManager() {}
 
     public static class SupportManagerFragment extends Fragment {
         protected boolean finishAfterDialog;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
