### PR TITLE
Cleanup - squid:S1481 - Unused local variables should be removed

### DIFF
--- a/app/src/main/java/com/stone/myapplication/MainActivity.java
+++ b/app/src/main/java/com/stone/myapplication/MainActivity.java
@@ -48,8 +48,6 @@ public class MainActivity extends ActionBarActivity {
         say();
         Log.i("aa", "bb");
         new MyException("","kk");
-        Tim t = Enum.valueOf(Tim.class, "AB");
-        Tim[] tims = Tim.values();
         Tim.valueOf("AC");
 
         PackageManager pm = getPackageManager();

--- a/app/src/main/java/com/stone/myapplication/MyAdapter.java
+++ b/app/src/main/java/com/stone/myapplication/MyAdapter.java
@@ -28,10 +28,8 @@ public class MyAdapter extends BaseAdapter {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
-        ViewHolder holder = null;
         if (convertView == null) {
             convertView = View.inflate(null, R.layout.my_text_view, null);
-            holder = new ViewHolder(convertView);
         }
         return convertView;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1481 - Unused local variables should be removed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1481

Please let me know if you have any questions.

M-Ezzat
